### PR TITLE
Add minimal web game skeleton

### DIFF
--- a/game/data/avatars.json
+++ b/game/data/avatars.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Naruto",
+        "rank": "genin",
+        "element": "wind",
+        "stats": {"attack": 5, "defense": 4, "chakra": 6, "speed": 5},
+        "attacks": ["Punch", "Rasengan", "Nine-Tails Strike"],
+        "level": 1,
+        "power": 10
+    },
+    {
+        "name": "Sasuke",
+        "rank": "genin",
+        "element": "lightning",
+        "stats": {"attack": 5, "defense": 4, "chakra": 6, "speed": 5},
+        "attacks": ["Kick", "Chidori", "Susanoo"],
+        "level": 1,
+        "power": 10
+    }
+]

--- a/game/data/missions.json
+++ b/game/data/missions.json
@@ -1,0 +1,8 @@
+[
+    {
+        "id": 1,
+        "name": "First Training",
+        "description": "Defeat one enemy",
+        "reward": {"xp": 100, "chakra": 50}
+    }
+]

--- a/game/data/packs.json
+++ b/game/data/packs.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "Training Scroll",
+        "rarity": "common",
+        "rewards": ["avatar", "chakra"]
+    },
+    {
+        "name": "Battle Scroll",
+        "rarity": "rare",
+        "rewards": ["avatar", "chakra", "materials"]
+    },
+    {
+        "name": "Legend Scroll",
+        "rarity": "epic",
+        "rewards": ["avatar", "chakra", "materials"]
+    }
+]

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Naruto Shinobi Multiverse</title>
+    <link rel="stylesheet" href="styles/style.css">
+</head>
+<body>
+    <h1>Naruto Shinobi Multiverse</h1>
+    <div id="game-container"></div>
+    <script src="scripts/game.js"></script>
+</body>
+</html>

--- a/game/scripts/combat.js
+++ b/game/scripts/combat.js
@@ -1,0 +1,12 @@
+export function startCombat(playerSquad, enemySquad) {
+    console.log('Combat start');
+    // Very basic turn simulation
+    let playerAttack = playerSquad[0].stats.attack;
+    let enemyAttack = enemySquad[0].stats.attack;
+
+    if (playerAttack >= enemyAttack) {
+        console.log('Player wins!');
+    } else {
+        console.log('Enemy wins!');
+    }
+}

--- a/game/scripts/game.js
+++ b/game/scripts/game.js
@@ -1,0 +1,34 @@
+import { startCombat } from './combat.js';
+import { openPack } from './packs.js';
+import { getMission } from './missions.js';
+
+class Player {
+    constructor(name) {
+        this.name = name;
+        this.level = 1;
+        this.xp = 0;
+        this.squad = [];
+        this.chakra = 0;
+    }
+}
+
+async function loadData(url) {
+    const res = await fetch(url);
+    return res.json();
+}
+
+async function initGame() {
+    const avatars = await loadData('data/avatars.json');
+    const packs = await loadData('data/packs.json');
+    const missions = await loadData('data/missions.json');
+
+    const player = new Player('Hero');
+    player.squad.push(avatars[0]);
+
+    document.getElementById('game-container').innerText = `Welcome, ${player.name}!`;
+    // Placeholder for combat
+    console.log('Start mission', missions[0]);
+    startCombat(player.squad, [avatars[1]]);
+}
+
+document.addEventListener('DOMContentLoaded', initGame);

--- a/game/scripts/missions.js
+++ b/game/scripts/missions.js
@@ -1,0 +1,4 @@
+export function getMission(id) {
+    // Placeholder mission lookup
+    return { id, name: 'Mission ' + id };
+}

--- a/game/scripts/packs.js
+++ b/game/scripts/packs.js
@@ -1,0 +1,5 @@
+export function openPack(pack) {
+    console.log('Opening', pack.name);
+    // Placeholder for pack rewards
+    return { avatar: null, chakra: 100 };
+}

--- a/game/styles/style.css
+++ b/game/styles/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f2f2f2;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
+#game-container {
+    width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- create `game` directory with HTML, CSS, JS assets
- include placeholder data for avatars, packs, missions
- implement simple start logic and combat stub

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d6d83d7e0832bb63fc631dff147e1